### PR TITLE
修复1.4版本抽卡数据中新增的id键导致的合并不能

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import json
-import time
 import requests
 import urllib.parse
 import os
@@ -37,6 +36,12 @@ def main():
     uid = gachaData["uid"]
     localDataFilePath = f"{gen_path}\\gachaData-{uid}.json"
 
+##### enhancement: store unmerged gachaData every time to avoid data destruction caused by merge errors ###################
+    import time
+    with open(f"{gen_path}\\gachaDataLog-{time.strftime('%Y-%m-%d_%H.%M.%S.jpg',time.localtime())}.json", "w", encoding="utf-8") as f:
+        json.dump(gachaData, f, ensure_ascii=False, sort_keys=False, indent=4)
+##### enhancement end #####################################################################################################
+
     if os.path.isfile(localDataFilePath):
         with open(localDataFilePath, "r", encoding="utf-8") as f:
             localData = json.load(f)
@@ -49,9 +54,6 @@ def main():
     with open(f"{gen_path}\\gachaData-{uid}.json", "w", encoding="utf-8") as f:
         json.dump(mergeData, f, ensure_ascii=False, sort_keys=False, indent=4)
     print("JSON", flush=True)
-    t = time.strftime("%Y%m%d%H%M%S", time.localtime())
-    with open(f"{gen_path}\\gachaData-{uid}-{t}.json", "w", encoding="utf-8") as f:
-        json.dump(gachaData, f, ensure_ascii=False, sort_keys=False, indent=4)
 
     if s.getKey("FLAG_CLEAN"):
         print("清除记录", end="...", flush=True)
@@ -85,6 +87,20 @@ def mergeDataFunc(localData, gachaData):
     for banner in gachaTypeDict:
         bannerLocal = localData["gachaLog"][banner]
         bannerGet = gachaData["gachaLog"][banner]
+
+########### bugfig: merge but ignore id, see issue#18(https://github.com/sunfkny/genshin-gacha-export/issues/18) ##########
+        for gachaGet in bannerLocal:
+            try:
+                del gachaGet["id"]
+            except KeyError:
+                pass
+        for gachaGet in bannerGet:
+            try:
+                del gachaGet["id"]
+            except KeyError:
+                pass
+########### bugfix end ####################################################################################################
+
         if bannerGet == bannerLocal:
             pass
         else:


### PR DESCRIPTION
在原神1.4版本更新后,导出的抽卡记录中多了id键  
这个key能为后续的合并提供方便,但却是和先前的版本不兼容的  
因此为保证在先前版本已经获取过抽卡记录的情况下能正确合并,先将id删去  
另外,在每次合并前都将本次获取到的数据缓存一份,以免后续更新中的不兼容破坏本地数据难以恢复  
