### PR TITLE
fix api domain for overseas genshin

### DIFF
--- a/main.py
+++ b/main.py
@@ -381,7 +381,10 @@ if __name__ == "__main__":
                     print("日志文件中没有链接")
                 else:
                     spliturl = url.split("?")
-                    spliturl[0] = "https://hk4e-api.mihoyo.com/event/gacha_info/api/getGachaLog"
+                    if "webstatic-sea" in spliturl[0] or "hk4e-api-os" in spliturl[0]:
+                        spliturl[0] = "https://hk4e-api-os.mihoyo.com/event/gacha_info/api/getGachaLog"
+                    else:
+                        spliturl[0] = "https://hk4e-api.mihoyo.com/event/gacha_info/api/getGachaLog"
                     url = "?".join(spliturl)
                     print("检查日志文件中的链接", end="...", flush=True)
                     if checkApi(url):


### PR DESCRIPTION
这两天无法使用这个工具导出国际版原神的抽卡数据了，试着参照这里的做法手动改了下 url 中的域名后成功导出了。
https://github.com/biuuu/genshin-wish-export/blob/ac5b019a2bf5a421c96dfb4359dad19cdf6bcf83/src/main/getData.js#L269