### PR TITLE
配置文件添加关闭检测更新功能，避免无法检测导致流程卡住

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,7 @@ version = "v2.4.0.01122052"
 
 class Config:
     setting = {
+        "FLAG_CHECK_UPDATE": True,
         "FLAG_MANUAL_INPUT_URL": False,
         "FLAG_AUTO_ARCHIVE": True,
         "FLAG_SHOW_REPORT": True,

--- a/main.py
+++ b/main.py
@@ -228,16 +228,18 @@ if __name__ == "__main__":
     url = ""
     gen_path = os.path.dirname(os.path.realpath(sys.argv[0]))
     s = Config(gen_path + "\\config.json")
-    latest = "https://pd.zwc365.com/seturl/https://raw.githubusercontent.com/sunfkny/genshin-gacha-export/main/version.txt"
-    try:
-        print("检查更新...",end="", flush=True)
-        latestversion = requests.get(latest).text
-        if version != latestversion:
-            print(f"当前版本{version}不是最新\n请到 https://github.com/sunfkny/genshin-gacha-export/releases 下载最新版本{latestversion}")
-        else:
-            print("OK")
-    except Exception:
-        print("检查更新失败", flush=True)
+    FLAG_CHECK_UPDATE = s.getKey("FLAG_CHECK_UPDATE")
+    if FLAG_CHECK_UPDATE:
+        latest = "https://pd.zwc365.com/seturl/https://raw.githubusercontent.com/sunfkny/genshin-gacha-export/main/version.txt"
+        try:
+            print("检查更新...",end="", flush=True)
+            latestversion = requests.get(latest).text
+            if version != latestversion:
+                print(f"当前版本{version}不是最新\n请到 https://github.com/sunfkny/genshin-gacha-export/releases 下载最新版本{latestversion}")
+            else:
+                print("OK")
+        except Exception:
+            print("检查更新失败", flush=True)
     FLAG_USE_CONFIG_URL = s.getKey("FLAG_USE_CONFIG_URL")
     if FLAG_USE_CONFIG_URL:
         print("检查配置文件中的链接", end="...", flush=True)


### PR DESCRIPTION
有部分网络环境无法检测更新，导致卡住无法继续，在配置文件中加入了FLAG_CHECK_UPDATE配置项